### PR TITLE
De-hardcoded bucket region

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -97,7 +97,7 @@ func main() {
 
 func runServer(c *cli.Context) {
 	sess := session.New(&aws.Config{
-		Region:      aws.String("us-west-1"),
+		Region:      aws.String(commonlib.BucketRegion),
 		Credentials: credentials.NewSharedCredentials("", "default"),
 	})
 	svc := s3.New(sess)


### PR DESCRIPTION
This was causing AWS to respond 301 to my requests unless the bucket was in us-west-1
