### PR TITLE
Represent ID and key as base 64 

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -156,7 +156,7 @@ func uploadEncrypted(stream io.Reader, messageSize int64, putURL string, headers
 	req.ContentLength = encrypter.TotalSize
 	commonlib.DEBUGPrintln("Content-Length set!")
 
-	/*//@DEBUG
+	/*//
 	dump, err := httputil.DumpRequestOut(req, false)
 	if err == nil {
 		commonlib.DEBUGPrintf("Request:\n")
@@ -274,8 +274,6 @@ func sendSecret(c *cli.Context) {
 		Filesize: fileSize,
 	}
 	metabytes, err := json.Marshal(filemeta)
-	//@DEBUG
-	commonlib.DEBUGPrintf("metabytes: %s\n", metabytes)
 
 	if err != nil {
 		fmt.Println("Internal error!")

--- a/client/main.go
+++ b/client/main.go
@@ -19,14 +19,15 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"os/user"
 	//"net/http/httputil"
-	"encoding/json"
 	"path/filepath"
 	"strings"
 
@@ -144,14 +145,14 @@ func uploadEncrypted(stream io.Reader, messageSize int64, putURL string, headers
 	req.ContentLength = encrypter.TotalSize
 	commonlib.DEBUGPrintln("Content-Length set!")
 
-	/*dump, err := httputil.DumpRequestOut(req, false)
+	/*//@DEBUG
+	dump, err := httputil.DumpRequestOut(req, false)
 	if err == nil {
-		fmt.Println("Request:")
-		fmt.Printf("%q", dump)
-		fmt.Println()
+		commonlib.DEBUGPrintf("Request:\n")
+		commonlib.DEBUGPrintf("%q\n\n", dump)
 	} else {
-		fmt.Println("Error dumping request!")
-		fmt.Println(err.Error())
+		commonlib.DEBUGPrintf("Error dumping request!\n")
+		commonlib.DEBUGPrintf("%s\n", err.Error())
 		os.Exit(1)
 	}*/
 
@@ -270,6 +271,9 @@ func sendSecret(c *cli.Context) {
 		Filesize: fileSize,
 	}
 	metabytes, err := json.Marshal(filemeta)
+	//@DEBUG
+	commonlib.DEBUGPrintf("metabytes: %s\n", metabytes)
+
 	if err != nil {
 		fmt.Println("Internal error!")
 		fmt.Println(err.Error())
@@ -327,7 +331,11 @@ func recvSecret(c *cli.Context) {
 	}
 
 	// Download metadata
-	resp, err := http.Get(fmt.Sprintf("https://s3-%s.amazonaws.com/%s/meta/%s", config.BucketRegion, config.Bucket, id))
+	resp, err := http.Get(fmt.Sprintf("https://s3-%s.amazonaws.com/%s/meta/%s",
+		url.QueryEscape(config.BucketRegion),
+		url.QueryEscape(config.Bucket),
+		url.QueryEscape(id),
+	))
 	if err != nil {
 		fmt.Println("Failed to download file!")
 		fmt.Println(err.Error())
@@ -335,6 +343,7 @@ func recvSecret(c *cli.Context) {
 	}
 	defer resp.Body.Close()
 	metabytes, err := ioutil.ReadAll(resp.Body)
+	fmt.Printf("x-golf %s\n", id)
 	if err != nil {
 		fmt.Println("Failed to download metadata!")
 		fmt.Println(err.Error())
@@ -374,7 +383,12 @@ func recvSecret(c *cli.Context) {
 	defer outf.Close()
 
 	// Download data
-	resp, err = http.Get(fmt.Sprintf("https://s3-%s.amazonaws.com/%s/%s", config.BucketRegion, config.Bucket, id))
+	resp, err = http.Get(fmt.Sprintf("https://s3-%s.amazonaws.com/%s/%s",
+		url.QueryEscape(config.BucketRegion),
+		url.QueryEscape(config.Bucket),
+		url.QueryEscape(id),
+	))
+
 	if err != nil {
 		fmt.Println("Failed to download file!")
 		fmt.Println(err.Error())

--- a/commonlib/commonlib.go
+++ b/commonlib/commonlib.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	APIVersion                  = 2
-	DEBUG                       = true
+	DEBUG                       = false
 	BadBlockSizeError           = errors.New("Block size is >256?  WTF?")
 	ShortReadError              = errors.New("Read was truncated, but then read more data!  This should never happen!")
 	NotEnoughKeyRandomnessError = errors.New("Not enough random bytes for key!  This should never happen!")

--- a/commonlib/commonlib.go
+++ b/commonlib/commonlib.go
@@ -84,3 +84,8 @@ func DEBUGPrintln(msg string) {
 func EncodeForHuman(bindata []byte) string {
 	return Encoding.EncodeToString(bindata)
 }
+
+// Decodes binary data from the ASCII format
+func DecodeForHuman(human string) ([]byte, error) {
+	return Encoding.DecodeString(human)
+}

--- a/commonlib/commonlib.go
+++ b/commonlib/commonlib.go
@@ -17,6 +17,7 @@ package commonlib
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -24,7 +25,7 @@ import (
 
 var (
 	APIVersion                  = 2
-	DEBUG                       = false
+	DEBUG                       = true
 	BadBlockSizeError           = errors.New("Block size is >256?  WTF?")
 	ShortReadError              = errors.New("Read was truncated, but then read more data!  This should never happen!")
 	NotEnoughKeyRandomnessError = errors.New("Not enough random bytes for key!  This should never happen!")
@@ -32,6 +33,12 @@ var (
 	DataCorruptionError         = errors.New("Encrypted data is corrupt!")
 	EncrypterWeirdEOFError      = errors.New("Encrypter: Read 0 bytes with no EOF!")
 	DecrypterWeirdEOFError      = errors.New("Decrypter: Read 0 bytes with no EOF!")
+
+	// We use a custom base-64 encoding because:
+	//
+	//   * '/' and '=' tend to introduce line breaks or breaks in text selection
+	//   * '/' is the path separator in S3
+	Encoding = base64.NewEncoding("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxzy0123456789+_").WithPadding(base64.NoPadding)
 )
 
 type ErrorResponse struct {
@@ -71,4 +78,9 @@ func DEBUGPrintln(msg string) {
 	if DEBUG {
 		fmt.Println("[DEBUG] " + msg)
 	}
+}
+
+// Encodes binary data for human copy/pasting.
+func EncodeForHuman(bindata []byte) string {
+	return Encoding.EncodeToString(bindata)
 }

--- a/server/main.go
+++ b/server/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"crypto/rand"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -43,12 +42,6 @@ var (
 	ErrIDShort = errors.New("Not enough random bytes for ID!  This should never happen!")
 	ErrPreSign = errors.New("Failed to generate pre-signed upload URL!")
 
-	// We use a custom base-64 encoding because:
-	//
-	//   * '/' and '=' tend to introduce line breaks or breaks in text selection
-	//   * '/' is the path separator in S3
-	Encoding = base64.NewEncoding("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxzy0123456789+_").WithPadding(base64.NoPadding)
-
 	Version           = 2 //deploy.sh:VERSION
 	DefaultConfigPath = "/etc/secretshare-server.json"
 )
@@ -68,7 +61,7 @@ func generateId() (string, error) {
 	if num_id_bytes < 32 {
 		return "", ErrIDShort
 	}
-	return Encoding.EncodeToString(idbin), nil
+	return commonlib.EncodeForHuman(idbin), nil
 }
 
 func generateSignedURL(svc *s3.S3, id, prefix string, ttl time.Duration) (string, http.Header, error) {

--- a/server/main.go
+++ b/server/main.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"crypto/rand"
-	"encoding/hex"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -43,6 +43,12 @@ var (
 	ErrIDShort = errors.New("Not enough random bytes for ID!  This should never happen!")
 	ErrPreSign = errors.New("Failed to generate pre-signed upload URL!")
 
+	// We use a custom base-64 encoding because:
+	//
+	//   * '/' and '=' tend to introduce line breaks or breaks in text selection
+	//   * '/' is the path separator in S3
+	Encoding = base64.NewEncoding("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxzy0123456789+_").WithPadding(base64.NoPadding)
+
 	Version           = 2 //deploy.sh:VERSION
 	DefaultConfigPath = "/etc/secretshare-server.json"
 )
@@ -62,7 +68,7 @@ func generateId() (string, error) {
 	if num_id_bytes < 32 {
 		return "", ErrIDShort
 	}
-	return hex.EncodeToString(idbin), nil
+	return Encoding.EncodeToString(idbin), nil
 }
 
 func generateSignedURL(svc *s3.S3, id, prefix string, ttl time.Duration) (string, http.Header, error) {


### PR DESCRIPTION
This isn't backwards compatible. The server, as well as both clients used in any transaction, will all need to be at this version or higher.
