### PR TITLE
Populate test-server.json from example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ test-server.log
 test-client.log
 commonlib/consts.go
 vars.json
+test-server.json
 install_linux.sh
 install_osx.sh
 build

--- a/setup_dev.sh
+++ b/setup_dev.sh
@@ -302,10 +302,11 @@ bucket=$(create_or_pick_bucket "${profile}")
 
 step=$((step+1))
 echo
-echo "${step} Populate vars.json"
+echo "${step} Populate client and server config files"
 echo
 secretshare_key=$(gen_secretshare_key)
 sed -e "s/us-west-1/${region}/; s/secretshare/${bucket}/; s/THISISABADKEY/${secretshare_key}/" vars.json.example > vars.json
+sed -e "s/THISISABADKEY/${secretshare_key}/" test-server.json.example > test-server.json
 
 
 step=$((step+1))

--- a/setup_dev.sh
+++ b/setup_dev.sh
@@ -336,7 +336,7 @@ aws_access_key_id = ${aws_keyid}
 aws_secret_access_key = ${aws_secret}
 region = ${region}
 EOF
-if [ -e "${HOME}/.aws/credentials" ]; then
+if [ -e "${HOME}/.aws/credentials" ] && ! [ -e "${HOME}/.aws/credentials.normal" ]; then
 	cp "${HOME}/.aws/credentials" "${HOME}/.aws/credentials.normal"
 else
 	# If this is empty, "credmgr off" will just delete the credentials file

--- a/test-server.json.example
+++ b/test-server.json.example
@@ -1,5 +1,5 @@
 {
     "addr": "0.0.0.0",
     "port": 8080,
-    "secret_key": ""
+    "secret_key": "THISISABADKEY"
 }


### PR DESCRIPTION
I figured there was no reason not to do this the same as the client.

I recommend re-cloning and re-running `setup_dev.sh` after this commit
so that nothing gets confused.

Also fixed a bug where sometimes the old instance of the server
would be running when you tried to test.
