### PR TITLE
Derive object ID from key so only one argument needs to be passed

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -297,7 +297,7 @@ Response body:
 	commonlib.DEBUGPrintf("URL: https://s3-%s.amazonaws.com/%s/%s\n",
 		config.BucketRegion, config.Bucket, idstr)
 	fmt.Println("To receive this secret:")
-	fmt.Printf("secretshare receive %s %s\n", idstr, keystr)
+	fmt.Printf("secretshare receive %s\n", keystr)
 	return nil
 }
 
@@ -331,12 +331,12 @@ func decrypt(ciphertext, key []byte) []byte {
 func recvSecret(c *cli.Context) error {
 	config.EndpointBaseURL = cleanUrl(c.Parent().String("endpoint"))
 	config.Bucket = c.Parent().String("bucket")
-	id := c.Args()[0]
-	keystr := c.Args()[1]
+	keystr := c.Args()[0]
 	key, err := commonlib.DecodeForHuman(keystr)
 	if err != nil {
 		return e("Invalid secret key given on command line: %s", err.Error())
 	}
+	id := deriveId(key)
 
 	// Download metadata
 	resp, err := http.Get(fmt.Sprintf("https://s3-%s.amazonaws.com/%s/meta/%s",

--- a/commonlib/commonlib.go
+++ b/commonlib/commonlib.go
@@ -46,7 +46,6 @@ type ErrorResponse struct {
 }
 
 type UploadResponse struct {
-	Id          string      `json:"id"`
 	PutURL      string      `json:"put_url"`
 	Headers     http.Header `json:"headers"`
 	MetaPutURL  string      `json:"meta_put_url"`
@@ -56,6 +55,7 @@ type UploadResponse struct {
 type UploadRequest struct {
 	TTL       int    `json:"ttl"`
 	SecretKey string `json:"secret_key"`
+	ObjectId  string `json:"object_id"`
 }
 
 type FileMetadata struct {

--- a/test.sh
+++ b/test.sh
@@ -88,9 +88,8 @@ fi
 rm test.txt
 echo 'Output from secretshare:' &> test-client.log
 echo -e "$client_out" > test-client.log
-id=$(echo "$client_out" | grep '^secretshare receive' | cut -d ' ' -f 3)
-key=$(echo "$client_out" | grep '^secretshare receive' | cut -d ' ' -f 4)
-$CLIENT receive "$id" "$key" &> test-client.log
+key=$(echo "$client_out" | grep '^secretshare receive' | cut -d ' ' -f 3)
+$CLIENT receive "$key" &> test-client.log
 kill $server_pid
 
 if [ ! -f test.txt ]; then


### PR DESCRIPTION
```
dan@george:~/go/src/github.com/waucka/secretshare$ ./build/osx-amd64/secretshare send /etc/passwd File uploaded!
To receive this secret:
secretshare receive [Key]

dan@george:~/go/src/github.com/waucka/secretshare$ ./build/osx-amd64/secretshare receive [Key]
File downloaded as passwd

dan@george:~/go/src/github.com/waucka/secretshare$ md5 passwd /etc/passwd
MD5 (passwd) = 5e7f80888f3d491c4963881364048c24
MD5 (/etc/passwd) = 5e7f80888f3d491c4963881364048c24
```
