### PR TITLE
Show source location

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Now suppose somebody runs `secretshare receive $KEY`, `$KEY` is the key from the
 1. The secretshare client downloads the metadata bundle from S3 and decrypts it.
 2. The secretshare client downloads the file from S3 and decrypts it, naming it according to the name in the metadata bundle.  If a file with that name already exists, it will prompt the user before overwriting it.  It decrypts the file on-the-fly, so large files can be decrypted without using an inordinate amount of memory.
 
+## Forking
+
+If you wish to fork, please update SourceLocation in vars.json.example to the location of your forked source code repository.
+
 ## Thanks
 
 Many thanks to my employer, [Exosite](https://exosite.com/), which gives its employees the freedom to open-source broadly useful tools like this.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Now suppose somebody runs `secretshare receive $KEY`, `$KEY` is the key from the
 1. The secretshare client downloads the metadata bundle from S3 and decrypts it.
 2. The secretshare client downloads the file from S3 and decrypts it, naming it according to the name in the metadata bundle.  If a file with that name already exists, it will prompt the user before overwriting it.  It decrypts the file on-the-fly, so large files can be decrypted without using an inordinate amount of memory.
 
+## Distribution
+
+When distributing, please change SourceLocation in vars.json to the location of the exact source code used to compile.
+
 ## Forking
 
 If you wish to fork, please update SourceLocation in vars.json.example to the location of your forked source code repository.

--- a/client/main.go
+++ b/client/main.go
@@ -465,6 +465,7 @@ func printVersion(c *cli.Context) error {
 	config.Bucket = c.Parent().String("bucket")
 	fmt.Printf("Client version: %d\n", Version)
 	fmt.Printf("Client API version: %d\n", commonlib.APIVersion)
+	fmt.Printf("Client source code: %s\n", commonlib.SourceLocation)
 
 	resp, err := http.Get(config.EndpointBaseURL + "/version")
 	if err != nil {
@@ -493,6 +494,7 @@ Response body:
 
 	fmt.Printf("Server version: %d\n", responseData.ServerVersion)
 	fmt.Printf("Server API version: %d\n", responseData.APIVersion)
+	fmt.Printf("Server source code: %s\n", responseData.ServerSourceLocation)
 
 	if commonlib.APIVersion != responseData.APIVersion {
 		return e("WARNING! Server and client APIs do not match!  Update your client.")

--- a/commonlib/commonlib.go
+++ b/commonlib/commonlib.go
@@ -66,6 +66,7 @@ type FileMetadata struct {
 type ServerVersionResponse struct {
 	ServerVersion int `json:"server_version"`
 	APIVersion    int `json:"api_version"`
+	ServerSourceLocation string `json:"server_source"`
 }
 
 func DEBUGPrintf(format string, args ...interface{}) {

--- a/server/main.go
+++ b/server/main.go
@@ -117,6 +117,7 @@ func runServer(c *cli.Context) {
 		c.JSON(http.StatusOK, &commonlib.ServerVersionResponse{
 			ServerVersion: Version,
 			APIVersion:    commonlib.APIVersion,
+			ServerSourceLocation: commonlib.SourceLocation,
 		})
 	})
 	r.POST("/upload", func(c *gin.Context) {

--- a/set_common_vars.py
+++ b/set_common_vars.py
@@ -11,6 +11,7 @@ var (
 	EndpointBaseURL = "{EndpointBaseURL}"
 	BucketRegion = "{BucketRegion}"
 	Bucket = "{Bucket}"
+	SourceLocation = "{SourceLocation}"
 )
 """.format(**vars_dict))
 

--- a/vars.json.example
+++ b/vars.json.example
@@ -2,5 +2,6 @@
     "EndpointBaseURL": "http://localhost:8080",
     "BucketRegion": "us-west-1",
     "Bucket": "secretshare",
-    "SecretKey": "THISISABADKEY"
+    "SecretKey": "THISISABADKEY",
+    "SourceLocation": "https://github.com/waucka/secretshare"
 }


### PR DESCRIPTION
Since this is AGPL code, we should really show the user where the source code can be found, for both the client and the server.
