### PR TITLE
Add Glide for package management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ aws_creds
 docker-secretshare-server.json
 test.txt
 test_env
+vendor

--- a/client/main.go
+++ b/client/main.go
@@ -36,7 +36,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/waucka/secretshare/commonlib"
 )
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,65 @@
+hash: b0fbbb5d9d232dbdb19122d2db841560a91754bf0656e2703395b5f179d132bf
+updated: 2016-09-15T14:07:16.228245433-05:00
+imports:
+- name: github.com/aws/aws-sdk-go
+  version: 3d4bac4e7e2ebd6f6b49de28d3232317af79c6fe
+  subpackages:
+  - aws
+  - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
+  - aws/corehandlers
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/request
+  - aws/session
+  - aws/signer/v4
+  - private/endpoints
+  - private/protocol
+  - private/protocol/query
+  - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/restxml
+  - private/protocol/xml/xmlutil
+  - private/waiter
+  - service/s3
+  - service/sts
+- name: github.com/codegangsta/cli
+  version: a14d7d367bc02b1f57d88de97926727f2d936387
+- name: github.com/gin-gonic/gin
+  version: f931d1ea80ae95a6fc739213cdd9399bd2967fb6
+  subpackages:
+  - binding
+  - render
+- name: github.com/go-ini/ini
+  version: 6e4869b434bd001f6983749881c7ead3545887d8
+- name: github.com/golang/protobuf
+  version: 2402d76f3d41f928c7902a765dfc872356dd3aad
+  subpackages:
+  - proto
+- name: github.com/jmespath/go-jmespath
+  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+- name: github.com/manucorporat/sse
+  version: ee05b128a739a0fb76c7ebd3ae4810c1de808d6d
+- name: github.com/Sirupsen/logrus
+  version: 3ec0642a7fb6488f65b06f9040adc67e3990296a
+- name: golang.org/x/net
+  version: f315505cf3349909cdf013ea56690da34e96a451
+  subpackages:
+  - context
+- name: golang.org/x/sys
+  version: 30de6d19a3bd89a5f38ae4028e23aaa5582648af
+  subpackages:
+  - unix
+- name: gopkg.in/go-playground/validator.v8
+  version: c193cecd124b5cc722d7ee5538e945bdb3348435
+- name: gopkg.in/yaml.v2
+  version: 31c299268d302dd0aa9a0dcf765a3d58971ac83f
+testImports:
+- name: gopkg.in/check.v1
+  version: 4f90aeace3a26ad7021961c297b22c42160c7b25

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b0fbbb5d9d232dbdb19122d2db841560a91754bf0656e2703395b5f179d132bf
-updated: 2016-09-15T14:07:16.228245433-05:00
+hash: 6248fd64a2f6ac6ccb5290f234b49dda7b4cd4d0edf4eff45b944a30bff2d3ce
+updated: 2016-09-15T14:11:39.29670353-05:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 3d4bac4e7e2ebd6f6b49de28d3232317af79c6fe
@@ -29,8 +29,6 @@ imports:
   - private/waiter
   - service/s3
   - service/sts
-- name: github.com/codegangsta/cli
-  version: a14d7d367bc02b1f57d88de97926727f2d936387
 - name: github.com/gin-gonic/gin
   version: f931d1ea80ae95a6fc739213cdd9399bd2967fb6
   subpackages:
@@ -48,6 +46,8 @@ imports:
   version: ee05b128a739a0fb76c7ebd3ae4810c1de808d6d
 - name: github.com/Sirupsen/logrus
   version: 3ec0642a7fb6488f65b06f9040adc67e3990296a
+- name: github.com/urfave/cli
+  version: a14d7d367bc02b1f57d88de97926727f2d936387
 - name: golang.org/x/net
   version: f315505cf3349909cdf013ea56690da34e96a451
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,17 @@
+package: github.com/waucka/secretshare
+import:
+- package: github.com/Sirupsen/logrus
+  version: master
+- package: github.com/aws/aws-sdk-go
+  version: ^1.4.9
+  subpackages:
+  - aws
+  - aws/credentials
+  - aws/session
+  - service/s3
+- package: github.com/codegangsta/cli
+  version: ^1.18.1
+- package: github.com/gin-gonic/gin
+  version: develop
+testImport:
+- package: gopkg.in/check.v1

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,7 +9,7 @@ import:
   - aws/credentials
   - aws/session
   - service/s3
-- package: github.com/codegangsta/cli
+- package: github.com/urfave/cli
   version: ^1.18.1
 - package: github.com/gin-gonic/gin
   version: develop

--- a/server/main.go
+++ b/server/main.go
@@ -33,7 +33,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/waucka/secretshare/commonlib"
 )
 


### PR DESCRIPTION
The current state of things means that no two builds are guaranteed to be identical because dependencies are not vendored or locked to specific versions. This fixes that.

You can read more about Glide [here](https://github.com/Masterminds/glide).

I've also changed the `codegangsta/cli` package to `urfave/cli` package. The git history is the same, but the former now redirects to the latter, and is now maintained at the latter, we're just making it explicit in case `codegangsta/cli` goes away.
