### PR TITLE
Version api breaking change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SECRETSHARE_VERSION=1.0
 COMMIT_ID=$(shell git rev-parse HEAD)
-GOBUILD=go build -ldflags "-X github.com/waucka/secretshare/commonlib.GitCommit=$(COMMIT_ID)"
+GO_LDFLAGS=-X github.com/waucka/secretshare/commonlib.GitCommit=$(COMMIT_ID) -X github.com/waucka/secretshare/commonlib.Version=$(SECRETSHARE_VERSION)
+GOBUILD=go build -ldflags "$(GO_LDFLAGS)"
 GOPATH=$(shell pwd)/packaging/gopath
 SERVER_DEPS=server/main.go commonlib/commonlib.go
 COMMON_CLIENT_DEPS=commonlib/commonlib.go commonlib/encrypter.go commonlib/decrypter.go commonlib/api.go

--- a/client/main.go
+++ b/client/main.go
@@ -326,7 +326,7 @@ Response body:
 %s`, err.Error(), bodyBytes)
 	}
 
-	fmt.Printf("Server version: %d\n", responseData.ServerVersion)
+	fmt.Printf("Server version: %s\n", responseData.ServerVersion)
 	fmt.Printf("Server API version: %d\n", responseData.APIVersion)
 	fmt.Printf("Server source code: %s\n", responseData.ServerSourceLocation)
 

--- a/client/main.go
+++ b/client/main.go
@@ -42,7 +42,6 @@ var (
 	config    clientConfig
 	secretKey string
 	homeDir   string
-	Version   = 5
 )
 
 // Returns a cli.ExitError with the given message, specified in a Printf-like way
@@ -298,7 +297,7 @@ func editConfig(c *cli.Context) error {
 func printVersion(c *cli.Context) error {
 	config.EndpointBaseURL = cleanUrl(c.Parent().String("endpoint"))
 	config.Bucket = c.Parent().String("bucket")
-	fmt.Printf("Client version: %d\n", Version)
+	fmt.Printf("Client version: %s\n", commonlib.Version)
 	fmt.Printf("Client API version: %d\n", commonlib.APIVersion)
 	fmt.Printf("Client source code: %s\n", commonlib.GetSourceLocation())
 
@@ -355,7 +354,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "secretshare"
 	app.Usage = "Securely share secrets"
-	app.Version = fmt.Sprintf("%d", Version)
+	app.Version = commonlib.Version
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "endpoint",

--- a/commonlib/commonlib.go
+++ b/commonlib/commonlib.go
@@ -41,6 +41,8 @@ var (
 	Encoding = base64.NewEncoding("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxzy0123456789+_").WithPadding(base64.NoPadding)
 )
 
+var Version string
+
 type ErrorResponse struct {
 	Message string `json:"message"`
 }
@@ -64,7 +66,7 @@ type FileMetadata struct {
 }
 
 type ServerVersionResponse struct {
-	ServerVersion        int    `json:"server_version"`
+	ServerVersion        string `json:"server_version"`
 	APIVersion           int    `json:"api_version"`
 	ServerSourceLocation string `json:"server_source"`
 }

--- a/guiclient/main.go
+++ b/guiclient/main.go
@@ -48,7 +48,6 @@ var (
 	config    clientConfig
 	secretKey string
 	homeDir   string
-	Version   = 5
 )
 
 func loadConfig(configPath string) error {
@@ -136,20 +135,20 @@ func writeKey(psk, keyPath string) error {
 }
 
 type versionInfo struct {
-	ClientVersion        int
+	ClientVersion        string
 	ClientApiVersion     int
 	ClientSourceLocation string
-	ServerVersion        int
+	ServerVersion        string
 	ServerApiVersion     int
 	ServerSourceLocation string
 }
 
 func fetchVersionInfo() (*versionInfo, error) {
 	info := &versionInfo{
-		ClientVersion:        Version,
+		ClientVersion:        commonlib.Version,
 		ClientApiVersion:     commonlib.APIVersion,
 		ClientSourceLocation: commonlib.GetSourceLocation(),
-		ServerVersion:        -1,
+		ServerVersion:        "ERROR",
 		ServerApiVersion:     -1,
 		ServerSourceLocation: "ERROR",
 	}
@@ -529,8 +528,8 @@ func aboutUi(parent *ui.Window, andthen afterFunc) {
 Copyright © 2016  Alexander Wauck
 License: AGPLv3
 
-Client Version: %d
-Server Version: %d
+Client Version: %s
+Server Version: %s
 
 Client API Version: %d
 Server API Version: %d

--- a/server/main.go
+++ b/server/main.go
@@ -42,7 +42,6 @@ var (
 	ErrIDShort = errors.New("Not enough random bytes for ID!  This should never happen!")
 	ErrPreSign = errors.New("Failed to generate pre-signed upload URL!")
 
-	Version           = 3 //deploy.sh:VERSION
 	DefaultConfigPath = "/etc/secretshare-server.json"
 	ReqIdChars        = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 	ReqIdLen          = 16
@@ -105,7 +104,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "secretshare-server"
 	app.Usage = "Securely share secrets"
-	app.Version = fmt.Sprintf("%d", Version)
+	app.Version = commonlib.Version
 	app.Action = runServer
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
@@ -152,7 +151,7 @@ func runServer(c *cli.Context) {
 	r.Use(reqIdMiddleware)
 	r.GET("/version", func(c *gin.Context) {
 		c.JSON(http.StatusOK, &commonlib.ServerVersionResponse{
-			ServerVersion:        Version,
+			ServerVersion:        commonlib.Version,
 			APIVersion:           commonlib.APIVersion,
 			ServerSourceLocation: commonlib.GetSourceLocation(),
 		})


### PR DESCRIPTION
Server and client versions are both strings now.  API versions are still integers.  This will break `secretshare version`, but everything else is OK.